### PR TITLE
Add 'bool SupportsScheme(CFStringRef aScheme) const' Application Controller Library Method to Introspect Support for a URL Scheme

### DIFF
--- a/src/lib/client/ApplicationControllerBasis.cpp
+++ b/src/lib/client/ApplicationControllerBasis.cpp
@@ -230,11 +230,11 @@ ControllerBasis :: Init(const Common::RunLoopParameters &aRunLoopParameters)
  *
  */
 bool
-ControllerBasis :: SupportsScheme(CFStringRef aScheme) const
+ControllerBasis :: SupportsScheme(CFStringRef aSchemeRef) const
 {
     bool lRetval;
 
-    lRetval = mConnectionManager.SupportsScheme(aScheme);
+    lRetval = mConnectionManager.SupportsScheme(aSchemeRef);
 
     return (lRetval);
 }

--- a/src/lib/client/ApplicationControllerBasis.cpp
+++ b/src/lib/client/ApplicationControllerBasis.cpp
@@ -215,6 +215,30 @@ ControllerBasis :: Init(const Common::RunLoopParameters &aRunLoopParameters)
     return (lRetval);
 }
 
+/**
+ *  @brief
+ *    Determine whether the controller supports connections with
+ *    the specified protocol scheme.
+ *
+ *  @param[in]  aSchemeRef  A reference to a CoreFoundation string
+ *                          containing the protocol (for example,
+ *                          "telnet") scheme for which to check
+ *                          support.
+ *
+ *  @returns
+ *     True if the scheme is supported; otherwise, false.
+ *
+ */
+bool
+ControllerBasis :: SupportsScheme(CFStringRef aScheme) const
+{
+    bool lRetval;
+
+    lRetval = mConnectionManager.SupportsScheme(aScheme);
+
+    return (lRetval);
+}
+
 // MARK: Accessors
 
 /**

--- a/src/lib/client/ApplicationControllerBasis.hpp
+++ b/src/lib/client/ApplicationControllerBasis.hpp
@@ -29,6 +29,8 @@
 
 #include <map>
 
+#include <CoreFoundation/CFString.h>
+
 #include <OpenHLX/Client/CommandManager.hpp>
 #include <OpenHLX/Client/ConnectionManager.hpp>
 #include <OpenHLX/Client/GroupsStateChangeNotifications.hpp>
@@ -79,6 +81,8 @@ public:
     // Initializer(s)
 
     Common::Status Init(const Common::RunLoopParameters &aRunLoopParameters);
+
+    bool SupportsScheme(CFStringRef aSchemeRef) const;
 
     // Accessors
 

--- a/src/lib/client/ConnectionFactory.cpp
+++ b/src/lib/client/ConnectionFactory.cpp
@@ -106,6 +106,34 @@ ConnectionFactory :: Init(const RunLoopParameters &aRunLoopParameters)
 
 /**
  *  @brief
+ *    Determine whether the factory supports creating a connection
+ *    with the specified protocol scheme.
+ *
+ *  @param[in]  aSchemeRef  A reference to a CoreFoundation string
+ *                          containing the protocol (for example,
+ *                          "telnet") scheme for which to check
+ *                          support.
+ *
+ *  @returns
+ *     True if the scheme is supported; otherwise, false.
+ *
+ */
+bool
+ConnectionFactory :: SupportsScheme(CFStringRef aSchemeRef) const
+{
+    const CFString lRequestedScheme(aSchemeRef);
+    bool lRetval = false;
+
+    if (lRequestedScheme == ConnectionTelnet::kScheme)
+    {
+        lRetval = true;
+    }
+
+    return (lRetval);
+}
+
+/**
+ *  @brief
  *    Return a connection for the protocol scheme associated with the
  *    specified peer URL.
  *

--- a/src/lib/client/ConnectionFactory.hpp
+++ b/src/lib/client/ConnectionFactory.hpp
@@ -64,6 +64,8 @@ public:
 
     Common::Status Init(const Common::RunLoopParameters &aRunLoopParameters);
 
+    bool SupportsScheme(CFStringRef aSchemeRef) const;
+
     ConnectionBasis *GetConnection(CFURLRef aURLRef) const;
 
 private:

--- a/src/lib/client/ConnectionManager.cpp
+++ b/src/lib/client/ConnectionManager.cpp
@@ -202,11 +202,11 @@ done:
  *
  */
 bool
-ConnectionManager :: SupportsScheme(CFStringRef aScheme) const
+ConnectionManager :: SupportsScheme(CFStringRef aSchemeRef) const
 {
     bool lRetval = false;
 
-    lRetval = mConnectionFactory.SupportsScheme(aScheme);
+    lRetval = mConnectionFactory.SupportsScheme(aSchemeRef);
 
     return (lRetval);
 }

--- a/src/lib/client/ConnectionManager.cpp
+++ b/src/lib/client/ConnectionManager.cpp
@@ -189,6 +189,30 @@ done:
 
 /**
  *  @brief
+ *    Determine whether the manager supports connections with the
+ *    specified protocol scheme.
+ *
+ *  @param[in]  aSchemeRef  A reference to a CoreFoundation string
+ *                          containing the protocol (for example,
+ *                          "telnet") scheme for which to check
+ *                          support.
+ *
+ *  @returns
+ *     True if the scheme is supported; otherwise, false.
+ *
+ */
+bool
+ConnectionManager :: SupportsScheme(CFStringRef aScheme) const
+{
+    bool lRetval = false;
+
+    lRetval = mConnectionFactory.SupportsScheme(aScheme);
+
+    return (lRetval);
+}
+
+/**
+ *  @brief
  *    Connect to a HLX server peer.
  *
  *  This attempts to asynchronously connect to the HLX server peer at

--- a/src/lib/client/ConnectionManager.hpp
+++ b/src/lib/client/ConnectionManager.hpp
@@ -72,6 +72,9 @@ public:
     virtual ~ConnectionManager(void) = default;
 
     Common::Status Init(const Common::RunLoopParameters &aRunLoopParameters);
+
+    bool SupportsScheme(CFStringRef aSchemeRef) const final;
+
     Common::Status Connect(const char *aMaybeURL, const Common::Timeout &aTimeout);
     Common::Status Connect(const char *aMaybeURL, const Versions &aVersions, const Common::Timeout &aTimeout);
     Common::Status Disconnect(void);

--- a/src/lib/common/ConnectionManagerBasis.hpp
+++ b/src/lib/common/ConnectionManagerBasis.hpp
@@ -112,6 +112,8 @@ public:
 
     const Roles & GetRoles(void) const;
 
+    virtual bool SupportsScheme(CFStringRef aSchemeRef) const = 0;
+
     ConnectionManagerApplicationDataDelegate *GetApplicationDataDelegate(void) const;
     Common::Status SetApplicationDataDelegate(ConnectionManagerApplicationDataDelegate *aDelegate);
 

--- a/src/lib/server/ApplicationControllerBasis.cpp
+++ b/src/lib/server/ApplicationControllerBasis.cpp
@@ -108,6 +108,30 @@ ControllerBasis :: Init(const Common::RunLoopParameters &aRunLoopParameters)
     return (lRetval);
 }
 
+/**
+ *  @brief
+ *    Determine whether the controller supports connections with
+ *    the specified protocol scheme.
+ *
+ *  @param[in]  aSchemeRef  A reference to a CoreFoundation string
+ *                          containing the protocol (for example,
+ *                          "telnet") scheme for which to check
+ *                          support.
+ *
+ *  @returns
+ *     True if the scheme is supported; otherwise, false.
+ *
+ */
+bool
+ControllerBasis :: SupportsScheme(CFStringRef aScheme) const
+{
+    bool lRetval;
+
+    lRetval = mConnectionManager.SupportsScheme(aScheme);
+
+    return (lRetval);
+}
+
 // MARK: Accessors
 
 /**

--- a/src/lib/server/ApplicationControllerBasis.cpp
+++ b/src/lib/server/ApplicationControllerBasis.cpp
@@ -123,11 +123,11 @@ ControllerBasis :: Init(const Common::RunLoopParameters &aRunLoopParameters)
  *
  */
 bool
-ControllerBasis :: SupportsScheme(CFStringRef aScheme) const
+ControllerBasis :: SupportsScheme(CFStringRef aSchemeRef) const
 {
     bool lRetval;
 
-    lRetval = mConnectionManager.SupportsScheme(aScheme);
+    lRetval = mConnectionManager.SupportsScheme(aSchemeRef);
 
     return (lRetval);
 }

--- a/src/lib/server/ApplicationControllerBasis.hpp
+++ b/src/lib/server/ApplicationControllerBasis.hpp
@@ -29,6 +29,8 @@
 
 #include <map>
 
+#include <CoreFoundation/CFString.h>
+
 #include <OpenHLX/Common/ApplicationObjectControllerContainerTemplate.hpp>
 #include <OpenHLX/Common/ConnectionManagerBasis.hpp>
 #include <OpenHLX/Common/Errors.hpp>
@@ -68,6 +70,8 @@ public:
     // Initializer(s)
 
     Common::Status Init(const Common::RunLoopParameters &aRunLoopParameters);
+
+    bool SupportsScheme(CFStringRef aSchemeRef) const;
 
     // Accessors
 

--- a/src/lib/server/ConnectionManager.cpp
+++ b/src/lib/server/ConnectionManager.cpp
@@ -130,11 +130,11 @@ done:
  *
  */
 bool
-ConnectionManager :: SupportsScheme(CFStringRef aScheme) const
+ConnectionManager :: SupportsScheme(CFStringRef aSchemeRef) const
 {
-    bool lRetval = false;
-
-    lRetval = mListenerFactory.SupportsScheme(aScheme);
+    const bool lListenersSupported   = mListenerFactory.SupportsScheme(aSchemeRef);
+    const bool lConnectionsSupported = mConnectionFactory.SupportsScheme(aSchemeRef);
+    const bool lRetval               = (lListenersSupported && lConnectionsSupported);
 
     return (lRetval);
 }

--- a/src/lib/server/ConnectionManager.cpp
+++ b/src/lib/server/ConnectionManager.cpp
@@ -115,6 +115,30 @@ done:
     return (lRetval);
 }
 
+/**
+ *  @brief
+ *    Determine whether the manager supports connections with the
+ *    specified protocol scheme.
+ *
+ *  @param[in]  aSchemeRef  A reference to a CoreFoundation string
+ *                          containing the protocol (for example,
+ *                          "telnet") scheme for which to check
+ *                          support.
+ *
+ *  @returns
+ *     True if the scheme is supported; otherwise, false.
+ *
+ */
+bool
+ConnectionManager :: SupportsScheme(CFStringRef aScheme) const
+{
+    bool lRetval = false;
+
+    lRetval = mListenerFactory.SupportsScheme(aScheme);
+
+    return (lRetval);
+}
+
 Status
 ConnectionManager :: Listen(const SocketAddress *aFirst, const SocketAddress *aLast)
 {

--- a/src/lib/server/ConnectionManager.hpp
+++ b/src/lib/server/ConnectionManager.hpp
@@ -79,6 +79,9 @@ public:
     virtual ~ConnectionManager(void) = default;
 
     Common::Status Init(const Common::RunLoopParameters &aRunLoopParameters);
+
+    bool SupportsScheme(CFStringRef aSchemeRef) const final;
+
     Common::Status Listen(void);
     Common::Status Listen(const Versions &aVersions);
     Common::Status Listen(const char *aMaybeURL);


### PR DESCRIPTION
This addresses #13 by adding a `bool SupportsScheme(CFStringRef aScheme) const` method from the client and server application controller bases down through to their underlying connection manager and factory to introspect support for a URL scheme.