### PR TITLE
Added systemd Start-up Service Configuration and Default Options Files for hlxproxyd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -976,6 +976,7 @@ src/lib/utilities/tests/Makefile
 tests/Makefile
 doc/Makefile
 doc/man/Makefile
+contrib/systemd/Makefile
 ])
 
 #

--- a/contrib/systemd/Makefile.am
+++ b/contrib/systemd/Makefile.am
@@ -1,0 +1,70 @@
+#
+#    Copyright 2022 Grant Erickson
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake template for the Open HLX
+#      systemd service makefile.
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+EXTRA_DIST                         = \
+    $(srcdir)/default                \
+    $(srcdir)/hlxproxyd.service.in   \
+    $(NULL)
+
+CLEANFILES                         = \
+    hlxproxyd.service                \
+    $(NULL)
+
+servicedir                         = $(libdir)/systemd/system
+service_DATA                       = hlxproxyd.service
+
+#
+# We choose to manually transform hlxproxyd.service.in into
+# hlxproxyd.service here in the makefile rather than in the configure
+# script so that we can take advantage of live, at build time, updating
+# of the file system paths.
+#
+
+hlxproxyd.service: $(srcdir)/hlxproxyd.service.in Makefile
+	$(AM_V_GEN)$(SED)                                     \
+	    -e "s,\@sbindir\@,$(sbindir),g"                   \
+	    -e "s,\@sysconfdir\@,$(sysconfdir),g"             \
+	    < "$(srcdir)/hlxproxyd.service.in" > "$(@)"
+
+#
+# We have a bespoke install rule for the defaults file since automake
+# does not have any canned way to install a file with a different
+# destination name than its source name.
+#
+
+install-data-local: $(DESTDIR)$(sysconfdir)/default/hlxproxyd
+
+$(DESTDIR)$(sysconfdir)/default:
+	@echo " $(MKDIR_P) '$(@)'"
+	$(AM_V_at)$(MKDIR_P) "$(@)"
+
+$(DESTDIR)$(sysconfdir)/default/hlxproxyd: $(srcdir)/default | $(DESTDIR)$(sysconfdir)/default
+	@echo " $(INSTALL_DATA) $(<) '$(@)'"
+	$(AM_V_at)$(INSTALL_DATA) "$(<)" "$(@)"
+
+uninstall-local:
+	@echo " rm -f '$(DESTDIR)$(sysconfdir)/default/hlxproxyd'"
+	-$(AM_V_at)rm -f $(DESTDIR)$(sysconfdir)/default/hlxproxyd
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/contrib/systemd/default
+++ b/contrib/systemd/default
@@ -21,4 +21,4 @@
 #
 
 # Command line options to pass to hlxproxyd on start-up.
-HLXPROXYD_OPTIONS="-c 192.168.1.151 --initial-refresh"
+HLXPROXYD_OPTIONS=

--- a/contrib/systemd/default
+++ b/contrib/systemd/default
@@ -1,0 +1,24 @@
+#    Copyright 2022 Grant Erickson. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the systemd default settings for Open HLX hlxproxyd,
+#      the Open HLX caching proxy daemon. This file is sourced by the
+#      shell from systemd.
+#
+
+# Command line options to pass to hlxproxyd on start-up.
+HLXPROXYD_OPTIONS="-c 192.168.1.151 --initial-refresh"

--- a/contrib/systemd/hlxproxyd.service.in
+++ b/contrib/systemd/hlxproxyd.service.in
@@ -1,0 +1,38 @@
+#
+#    Copyright 2022 Grant Erickson. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the systemd service file for Open HLX hlxproxyd,
+#      the Open HLX caching proxy daemon.
+#
+
+[Unit]
+Description=Open HLX caching proxy daemon
+Documentation=man:hlxproxyd(1)
+Wants=network-online.target
+After=network-online.target network.target
+
+[Service]
+Type=simple
+EnvironmentFile=-@sysconfdir@/default/hlxproxyd
+ExecStart=@sbindir@/hlxproxyd $HLXPROXYD_OPTIONS
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+Alias=hlxproxyd.service

--- a/src/hlxproxyd/Makefile.am
+++ b/src/hlxproxyd/Makefile.am
@@ -40,7 +40,7 @@ noinst_HEADERS                                                             = \
     ZonesController.hpp                                                      \
     $(NULL)
 
-bin_PROGRAMS                                                               = \
+sbin_PROGRAMS                                                              = \
     hlxproxyd                                                                \
     $(NULL)
 

--- a/src/hlxsimd/Makefile.am
+++ b/src/hlxsimd/Makefile.am
@@ -45,7 +45,7 @@ noinst_HEADERS                                                             = \
     ZonesController.hpp                                                      \
     $(NULL)
 
-bin_PROGRAMS                                                               = \
+sbin_PROGRAMS                                                              = \
     hlxsimd                                                                  \
     $(NULL)
 


### PR DESCRIPTION
This addresses #19 by adding a _systemd_ start-up service configuration and default options file for _hlxproxyd_.