### PR TITLE
Rebase the Group and Zone Output Model Classes on a Common Ancestor

### DIFF
--- a/src/lib/model/GroupModel.cpp
+++ b/src/lib/model/GroupModel.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2019-2021 Grant Erickson
+ *    Copyright (c) 2019-2024 Grant Erickson
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,12 +40,6 @@ namespace Model
 {
 
 /**
- *  The maximum allowed length, in bytes, of a group name.
- *
- */
-const size_t GroupModel::kNameLengthMax = NameModel::kNameLengthMax;
-
-/**
  *  @brief
  *    This is the class default initializer.
  *
@@ -62,16 +56,10 @@ GroupModel :: Init(void)
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init();
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mName.Init();
+    lRetval = OutputModelBasis::Init();
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mSources.Init();
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mVolume.Init();
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mZones.Init();
@@ -103,16 +91,10 @@ GroupModel :: Init(const char *aName, const IdentifierType &aIdentifier)
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init(aIdentifier);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mName.Init(aName);
+    lRetval = OutputModelBasis::Init(aName, aIdentifier);
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mSources.Init();
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mVolume.Init();
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mZones.Init();
@@ -147,16 +129,10 @@ GroupModel :: Init(const char *aName, const size_t &aNameLength, const Identifie
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init(aIdentifier);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mName.Init(aName, aNameLength);
+    lRetval = OutputModelBasis::Init(aName, aNameLength, aIdentifier);
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mSources.Init();
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mVolume.Init();
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mZones.Init();
@@ -188,16 +164,10 @@ GroupModel :: Init(const std::string &aName, const IdentifierType &aIdentifier)
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init(aIdentifier);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mName.Init(aName);
+    lRetval = OutputModelBasis::Init(aName, aIdentifier);
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mSources.Init();
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mVolume.Init();
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mZones.Init();
@@ -224,16 +194,10 @@ GroupModel :: Init(const GroupModel &aGroupModel)
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init(aGroupModel.mIdentifier);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mName.Init(aGroupModel.mName);
+    lRetval = OutputModelBasis::Init(aGroupModel);
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mSources.Init(aGroupModel.mSources);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
-    lRetval = mVolume.Init(aGroupModel.mVolume);
     nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mZones.Init(aGroupModel.mZones);
@@ -262,10 +226,9 @@ GroupModel :: Init(const GroupModel &aGroupModel)
 GroupModel &
 GroupModel :: operator =(const GroupModel &aGroupModel)
 {
-    mIdentifier = aGroupModel.mIdentifier;
-    mName       = aGroupModel.mName;
+    OutputModelBasis::operator =(aGroupModel);
+
     mSources    = aGroupModel.mSources;
-    mVolume     = aGroupModel.mVolume;
     mZones      = aGroupModel.mZones;
 
     return (*this);
@@ -296,104 +259,6 @@ bool
 GroupModel :: ContainsZone(const ZoneModel::IdentifierType &aZoneIdentifier) const
 {
     return (mZones.ContainsIdentifier(aZoneIdentifier));
-}
-
-/**
- *  @brief
- *    Attempt to get the group identifier.
- *
- *  This attempts to get the group identifier, if it has been
- *  previously initialized or set.
- *
- *  @param[out]  aIdentifier  A mutable reference to storage for the
- *                            group identifier, if successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the group identifier
- *                                  value has not been initialized
- *                                  with a known value.
- *
- *  @sa Init
- *  @sa SetIdentifier
- *
- */
-Status
-GroupModel :: GetIdentifier(IdentifierType &aIdentifier) const
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mIdentifier.GetIdentifier(aIdentifier);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    Attempt to get the group name
- *
- *  This attempts to get the group name, if it has been previously
- *  initialized or set.
- *
- *  @param[out]  aName  A reference to pointer to an immutable
- *                      null-terminated C string for the group
- *                      name, if successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the group name value has
- *                                  not been initialized with a known
- *                                  value.
- *
- *  @sa Init
- *  @sa SetName
- *
- *  @ingroup name
- *
- */
-Status
-GroupModel :: GetName(const char *&aName) const
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mName.GetName(aName);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    Attempt to get the model group volume mute state.
- *
- *  This attempts to get the model group volume mute state, if it has
- *  been previously initialized or set.
- *
- *  @param[out]  aMute  A mutable reference to storage for the
- *                      group volume mute state, if successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the group volume mute state
- *                                  value has not been initialized
- *                                  with a known value.
- *
- *  @sa SetMute
- *  @sa ToggleMute
- *
- *  @ingroup volume
- *
- */
-Status
-GroupModel :: GetMute(MuteType &aMute) const
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.GetMute(aMute);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
- done:
-    return (lRetval);
 }
 
 /**
@@ -483,38 +348,6 @@ GroupModel :: GetSources(Sources &aSourceIdentifiers) const
 
     aSourceIdentifiers = mSources;
 
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    Attempt to get the model group volume level.
- *
- *  This attempts to get the model group volume level, if it has been
- *  previously initialized or set.
- *
- *  @param[out]  aLevel  A mutable reference to storage for the
- *                       group volume level, if successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the group volume level value
- *                                  has not been initialized with a
- *                                  known value.
- *
- *  @sa SetVolume
- *
- *  @ingroup volume
- *
- */
-Status
-GroupModel :: GetVolume(LevelType &aLevel) const
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.GetVolume(aLevel);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
- done:
     return (lRetval);
 }
 
@@ -640,78 +473,6 @@ GroupModel :: ClearZones(void)
 
 /**
  *  @brief
- *    Decrease the model group volume level by one (1) unit.
- *
- *  This attempts to decrease the model group volume level by one (1)
- *  unit.
- *
- *  @param[out]  aOutLevel  A mutable reference to storage for the
- *                          resulting group volume level, if
- *                          successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the group volume level value
- *                                  has not been initialized with a
- *                                  known value.
- *  @retval  -ERANGE                The attempted adjustment would result
- *                                  in a level that would exceed the
- *                                  minimum group volume level.
- *
- *  @sa SetVolume
- *
- *  @ingroup volume
- *
- */
-Status
-GroupModel :: DecreaseVolume(LevelType &aOutLevel)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.DecreaseVolume(aOutLevel);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    Increase the model group volume level by one (1) unit.
- *
- *  This attempts to increase the model group volume level by one (1)
- *  unit.
- *
- *  @param[out]  aOutLevel  A mutable reference to storage for the
- *                          resulting group volume level, if
- *                          successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the group volume level value
- *                                  has not been initialized with a
- *                                  known value.
- *  @retval  -ERANGE                The attempted adjustment would result
- *                                  in a level that would exceed the
- *                                  maximum group volume level.
- *
- *  @sa SetVolume
- *
- *  @ingroup volume
- *
- */
-Status
-GroupModel :: IncreaseVolume(LevelType &aOutLevel)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.IncreaseVolume(aOutLevel);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
  *    Attempt to remove (disassociate) a source (input) identifier
  *    from the group model.
  *
@@ -755,126 +516,6 @@ Status
 GroupModel :: RemoveZone(const ZoneModel::IdentifierType &aZoneIdentifier)
 {
     return (RemoveIdentifier(mZones, aZoneIdentifier));
-}
-
-/**
- *  @brief
- *    This sets the model group identifier.
- *
- *  This attempts to set the model with the group identifier.
- *
- *  @param[in]  aIdentifier  An immutable reference to the group
- *                           identifier to set.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified @a aIdentifier value
- *                                    has already been set.
- *  @retval  -EINVAL                  The specified @a aIdentifier value
- *                                    is invalid.
- *
- */
-Status
-GroupModel :: SetIdentifier(const IdentifierType &aIdentifier)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mIdentifier.SetIdentifier(aIdentifier);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    This sets the model group name.
- *
- *  This attempts to set the model with the specified group name.
- *
- *  @param[in]  aName        A pointer to the start of the null-
- *                           terminated C string name to set.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified name has already
- *                                    been set.
- *  @retval  -EINVAL                  If @a aName was null.
- *  @retval  -ENAMETOOLONG            If @a aName was too long.
- *
- *  @ingroup name
- *
- */
-Status
-GroupModel :: SetName(const char *aName)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mName.SetName(aName);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    This sets the model group name.
- *
- *  This attempts to set the model with the specified group name
- *  extent.
- *
- *  @param[in]  aName        A pointer to the start of the string name
- *                           to set.
- *  @param[in]  aNameLength  An immutable reference to the length,
- *                           in bytes, of @a aName.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified name has already
- *                                    been set.
- *  @retval  -EINVAL                  If @a aName was null.
- *  @retval  -ENAMETOOLONG            If @a aNameLength was too long.
- *
- *  @ingroup name
- *
- */
-Status
-GroupModel :: SetName(const char *aName, const size_t &aNameLength)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mName.SetName(aName, aNameLength);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    This sets the model group volume mute state.
- *
- *  This attempts to set the model with the specified group volume
- *  mute state.
- *
- *  @param[in]  aMute  An immutable reference to the group
- *                     volume mute state to set.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified @a aMute value
- *                                    has already been set.
- *
- *  @ingroup volume
- *
- */
-Status
-GroupModel :: SetMute(const MuteType &aMute)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.SetMute(aMute);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
 }
 
 /**
@@ -998,67 +639,6 @@ GroupModel :: SetSources(const Sources &aSourceIdentifiers)
 
 /**
  *  @brief
- *    This sets the model group volume level.
- *
- *  This attempts to set the model with the specified group volume
- *  level.
- *
- *  @param[in]  aLevel  An immutable reference to the group volume
- *                      level to set.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified @a aLevel value
- *                                    has already been set.
- *  @retval  -ERANGE                  The specified @a aLevel value
- *                                    is out of range.
- *
- *  @ingroup volume
- *
- */
-Status
-GroupModel :: SetVolume(const LevelType &aLevel)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.SetVolume(aLevel);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    Attempt to toggle (flip) the model group volume mute state.
- *
- *  This attempts to toggle (flip) the model group volume mute state.
- *
- *  @param[out]  aOutMute  A mutable reference to storage for the
- *                         resulting group volume mute state, if
- *                         successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the group volume mute state
- *                                  value has not been initialized
- *                                  with a known value.
- *
- *  @ingroup volume
- *
- */
-Status
-GroupModel :: ToggleMute(MuteType &aOutMute)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.ToggleMute(aOutMute);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
  *    This is a class equality operator.
  *
  *  This compares the provided group model against this one to
@@ -1075,11 +655,9 @@ GroupModel :: ToggleMute(MuteType &aOutMute)
 bool
 GroupModel :: operator ==(const GroupModel &aGroupModel) const
 {
-    return ((mIdentifier       == aGroupModel.mIdentifier) &&
-            (mName             == aGroupModel.mName      ) &&
-            (mSources          == aGroupModel.mSources   ) &&
-            (mVolume           == aGroupModel.mVolume    ) &&
-            (mZones            == aGroupModel.mZones     ));
+    return (OutputModelBasis::operator ==(aGroupModel)          &&
+            (mSources                  == aGroupModel.mSources) &&
+            (mZones                    == aGroupModel.mZones  ));
 }
 
 /**

--- a/src/lib/model/GroupModel.hpp
+++ b/src/lib/model/GroupModel.hpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2019-2021 Grant Erickson
+ *    Copyright (c) 2019-2024 Grant Erickson
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,8 @@
 
 /**
  *    @file
- *      This file defines an object for managing a HLX group data model.
+ *      This file defines an object for managing a HLX group data
+ *      model.
  *
  */
 
@@ -32,10 +33,8 @@
 
 #include <OpenHLX/Common/Errors.hpp>
 #include <OpenHLX/Model/IdentifiersCollection.hpp>
-#include <OpenHLX/Model/IdentifierModel.hpp>
-#include <OpenHLX/Model/NameModel.hpp>
+#include <OpenHLX/Model/OutputModelBasis.hpp>
 #include <OpenHLX/Model/SourceModel.hpp>
-#include <OpenHLX/Model/VolumeModel.hpp>
 #include <OpenHLX/Model/ZoneModel.hpp>
 
 
@@ -53,31 +52,10 @@ namespace Model
  *  @ingroup group
  *
  */
-class GroupModel
+class GroupModel :
+    public OutputModelBasis
 {
 public:
-    static const size_t kNameLengthMax;
-
-    /**
-     *  Convenience type redeclaring @a IdentifierType from the
-     *  identifier model.
-     *
-     */
-    typedef IdentifierModel::IdentifierType IdentifierType;
-    /**
-     *  Convenience type redeclaring @a MuteType from the
-     *  volume model.
-     *
-     */
-    typedef VolumeModel::MuteType           MuteType;
-
-    /**
-     *  Convenience type redeclaring @a LevelType from the
-     *  volume model.
-     *
-     */
-    typedef VolumeModel::LevelType          LevelType;
-
     /**
      *  Type for a collection of group source (input) identifiers.
      *
@@ -98,33 +76,20 @@ public:
 
     bool   ContainsZone(const ZoneModel::IdentifierType &aZoneIdentifier) const;
 
-    Common::Status GetIdentifier(IdentifierType &aIdentifier) const;
-    Common::Status GetName(const char *&aName) const;
-    Common::Status GetMute(MuteType &aMute) const;
     Common::Status GetSources(size_t &aCount) const;
     Common::Status GetSources(SourceModel::IdentifierType *aSourceIdentifiers, size_t &aCount) const;
     Common::Status GetSources(Sources &aSourceIdentifiers) const;
-    Common::Status GetVolume(LevelType &aVolume) const;
     Common::Status GetZones(size_t &aCount) const;
     Common::Status GetZones(ZoneModel::IdentifierType *aZoneIdentifiers, size_t &aCount) const;
 
     Common::Status AddSource(const SourceModel::IdentifierType &aSourceIdentifier);
     Common::Status AddZone(const ZoneModel::IdentifierType &aZoneIdentifier);
     Common::Status ClearZones(void);
-    Common::Status DecreaseVolume(LevelType &aOutLevel);
-    Common::Status IncreaseVolume(LevelType &aOutLevel);
     Common::Status RemoveSource(const SourceModel::IdentifierType &aSourceIdentifier);
     Common::Status RemoveZone(const ZoneModel::IdentifierType &aZoneIdentifier);
-    Common::Status SetIdentifier(const IdentifierType &aIdentifier);
-    Common::Status SetName(const char *aName);
-    Common::Status SetName(const char *aName, const size_t &aNameLength);
-    Common::Status SetMute(const MuteType &aMute);
     Common::Status SetSource(const SourceModel::IdentifierType &aSourceIdentifier);
     Common::Status SetSources(const SourceModel::IdentifierType *aSourceIdentifiers, const size_t &aCount);
     Common::Status SetSources(const Sources &aSourceIdentifiers);
-
-    Common::Status SetVolume(const LevelType &aVolume);
-    Common::Status ToggleMute(MuteType &aOutMute);
 
     bool operator ==(const GroupModel &aGroupModel) const;
 
@@ -142,10 +107,7 @@ private:
      */
     typedef IdentifiersCollection  Zones;
 
-    IdentifierModel  mIdentifier;
-    NameModel        mName;
     Sources          mSources;
-    VolumeModel      mVolume;
     Zones            mZones;
 };
 

--- a/src/lib/model/Makefile.am
+++ b/src/lib/model/Makefile.am
@@ -64,6 +64,7 @@ libopenhlx_model_a_include_HEADERS                          = \
     InfraredModel.hpp                                         \
     NameModel.hpp                                             \
     NetworkModel.hpp                                          \
+    OutputModelBasis.hpp                                      \
     SoundModel.hpp                                            \
     SourceModel.hpp                                           \
     SourcesModel.hpp                                          \
@@ -96,6 +97,7 @@ libopenhlx_model_a_SOURCES                                  = \
     InfraredModel.cpp                                         \
     NameModel.cpp                                             \
     NetworkModel.cpp                                          \
+    OutputModelBasis.cpp                                      \
     SoundModel.cpp                                            \
     SourceModel.cpp                                           \
     SourcesModel.cpp                                          \

--- a/src/lib/model/OutputModelBasis.cpp
+++ b/src/lib/model/OutputModelBasis.cpp
@@ -1,0 +1,651 @@
+/*
+ *    Copyright (c) 2024 Grant Erickson
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing,
+ *    software distributed under the License is distributed on an "AS
+ *    IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied.  See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ */
+
+/**
+ *    @file
+ *      This file implements an object for managing a HLX output data
+ *      model.
+ *
+ */
+
+#include "OutputModelBasis.hpp"
+
+#include <errno.h>
+
+#include <OpenHLX/Common/Errors.hpp>
+#include <OpenHLX/Utilities/Assert.hpp>
+
+
+using namespace HLX::Common;
+
+
+namespace HLX
+{
+
+namespace Model
+{
+
+/**
+ *  The maximum allowed length, in bytes, of an output name.
+ *
+ */
+const size_t OutputModelBasis::kNameLengthMax = NameModel::kNameLengthMax;
+
+/**
+ *  @brief
+ *    This is the class default initializer.
+ *
+ *  This initializes the model with a null name and identifier.
+ *
+ *  @retval  kStatus_Success  If successful.
+ *
+ *  @sa SetIdentifier
+ *  @sa SetName
+ *
+ */
+Status
+OutputModelBasis :: Init(void)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mIdentifier.Init();
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mName.Init();
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mVolume.Init();
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This is a class initializer.
+ *
+ *  This initializes the model with the specified name and identifier.
+ *
+ *  @param[in]  aName        A pointer to the null-terminated C string
+ *                           to initialze the output name with.
+ *  @param[in]  aIdentifier  An immutable reference for the output
+ *                           identifier to initialize with.
+ *
+ *  @retval  kStatus_Success  If successful.
+ *  @retval  -EINVAL          If @a aIdentifier was invalid or if @a
+ *                            aName was null.
+ *  @retval  -ENAMETOOLONG    If @a aName was too long.
+ *
+ */
+Status
+OutputModelBasis :: Init(const char *aName, const IdentifierType &aIdentifier)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mIdentifier.Init(aIdentifier);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mName.Init(aName);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mVolume.Init();
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This is a class initializer.
+ *
+ *  This initializes the model with the specified name extent and
+ *  identifier.
+ *
+ *  @param[in]  aName        A pointer to the start of the string
+ *                           name to set.
+ *  @param[in]  aNameLength  An immutable reference to the length,
+ *                           in bytes, of @a aName.
+ *  @param[in]  aIdentifier  An immutable reference for the output
+ *                           identifier to initialize with.
+ *
+ *  @retval  kStatus_Success  If successful.
+ *  @retval  -EINVAL          If @a aIdentifier was invalid or if @a
+ *                            aName was null.
+ *  @retval  -ENAMETOOLONG    If @a aNameLength was too long.
+ *
+ */
+Status
+OutputModelBasis :: Init(const char *aName, const size_t &aNameLength, const IdentifierType &aIdentifier)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mIdentifier.Init(aIdentifier);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mName.Init(aName, aNameLength);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mVolume.Init();
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This is a class initializer.
+ *
+ *  This initializes the model with the specified name and identifier.
+ *
+ *  @param[in]  aName        A pointer the string to initialze the
+ *                           output name with.
+ *  @param[in]  aIdentifier  An immutable reference for the output
+ *                           identifier to initialize with.
+ *
+ *  @retval  kStatus_Success  If successful.
+ *  @retval  -EINVAL          If @a aIdentifier was invalid or if @a
+ *                            aName was null.
+ *  @retval  -ENAMETOOLONG    If @a aName was too long.
+ *
+ */
+Status
+OutputModelBasis :: Init(const std::string &aName, const IdentifierType &aIdentifier)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mIdentifier.Init(aIdentifier);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mName.Init(aName);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mVolume.Init();
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This is a class copy initializer.
+ *
+ *  This initializes the class with the specified output model.
+ *
+ *  @param[in]  aOutputModelBasis  An immutable reference to the
+ *                                 output model to initialize with.
+ *
+ *  @retval  kStatus_Success  Unconditionally.
+ *
+ */
+Status
+OutputModelBasis :: Init(const OutputModelBasis &aOutputModelBasis)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mIdentifier.Init(aOutputModelBasis.mIdentifier);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mName.Init(aOutputModelBasis.mName);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+    lRetval = mVolume.Init(aOutputModelBasis.mVolume);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This is a class assignment (copy) operator.
+ *
+ *  This assigns (copies) the specified output model to this one.
+ *
+ *  @param[in]  aOutputModelBasis  An immutable reference to the
+ *                                 output model to assign (copy)
+ *                                 to this one.
+ *
+ *
+ *  @returns
+ *    A reference to this output model after the assignment (copy)
+ *    is complete.
+ *
+ */
+OutputModelBasis &
+OutputModelBasis :: operator =(const OutputModelBasis &aOutputModelBasis)
+{
+    mIdentifier = aOutputModelBasis.mIdentifier;
+    mName       = aOutputModelBasis.mName;
+    mVolume     = aOutputModelBasis.mVolume;
+
+    return (*this);
+}
+
+/**
+ *  @brief
+ *    Attempt to get the output identifier.
+ *
+ *  This attempts to get the output identifier, if it has been
+ *  previously initialized or set.
+ *
+ *  @param[out]  aIdentifier  A mutable reference to storage for the
+ *                            output identifier, if successful.
+ *
+ *  @retval  kStatus_Success        If successful.
+ *  @retval  kError_NotInitialized  If the output identifier
+ *                                  value has not been initialized
+ *                                  with a known value.
+ *
+ *  @sa Init
+ *  @sa SetIdentifier
+ *
+ */
+Status
+OutputModelBasis :: GetIdentifier(IdentifierType &aIdentifier) const
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mIdentifier.GetIdentifier(aIdentifier);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    Attempt to get the output name
+ *
+ *  This attempts to get the output name, if it has been previously
+ *  initialized or set.
+ *
+ *  @param[out]  aName  A reference to pointer to an immutable
+ *                      null-terminated C string for the output
+ *                      name, if successful.
+ *
+ *  @retval  kStatus_Success        If successful.
+ *  @retval  kError_NotInitialized  If the output name value has
+ *                                  not been initialized with a known
+ *                                  value.
+ *
+ *  @sa Init
+ *  @sa SetName
+ *
+ *  @ingroup name
+ *
+ */
+Status
+OutputModelBasis :: GetName(const char *&aName) const
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mName.GetName(aName);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    Attempt to get the model output volume mute state.
+ *
+ *  This attempts to get the model output volume mute state, if it has
+ *  been previously initialized or set.
+ *
+ *  @param[out]  aMute  A mutable reference to storage for the
+ *                      output volume mute state, if successful.
+ *
+ *  @retval  kStatus_Success        If successful.
+ *  @retval  kError_NotInitialized  If the output volume mute state
+ *                                  value has not been initialized
+ *                                  with a known value.
+ *
+ *  @sa SetMute
+ *  @sa ToggleMute
+ *
+ *  @ingroup volume
+ *
+ */
+Status
+OutputModelBasis :: GetMute(MuteType &aMute) const
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mVolume.GetMute(aMute);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    Attempt to get the model output volume level.
+ *
+ *  This attempts to get the model output volume level, if it has been
+ *  previously initialized or set.
+ *
+ *  @param[out]  aLevel  A mutable reference to storage for the
+ *                       output volume level, if successful.
+ *
+ *  @retval  kStatus_Success        If successful.
+ *  @retval  kError_NotInitialized  If the output volume level value
+ *                                  has not been initialized with a
+ *                                  known value.
+ *
+ *  @sa SetVolume
+ *
+ *  @ingroup volume
+ *
+ */
+Status
+OutputModelBasis :: GetVolume(LevelType &aLevel) const
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mVolume.GetVolume(aLevel);
+    nlREQUIRE_SUCCESS(lRetval, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    Decrease the model output volume level by one (1) unit.
+ *
+ *  This attempts to decrease the model output volume level by one (1)
+ *  unit.
+ *
+ *  @param[out]  aOutLevel  A mutable reference to storage for the
+ *                          resulting output volume level, if
+ *                          successful.
+ *
+ *  @retval  kStatus_Success        If successful.
+ *  @retval  kError_NotInitialized  If the output volume level value
+ *                                  has not been initialized with a
+ *                                  known value.
+ *  @retval  -ERANGE                The attempted adjustment would result
+ *                                  in a level that would exceed the
+ *                                  minimum output volume level.
+ *
+ *  @sa SetVolume
+ *
+ *  @ingroup volume
+ *
+ */
+Status
+OutputModelBasis :: DecreaseVolume(LevelType &aOutLevel)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mVolume.DecreaseVolume(aOutLevel);
+    nlREQUIRE(lRetval >= kStatus_Success, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    Increase the model output volume level by one (1) unit.
+ *
+ *  This attempts to increase the model output volume level by one (1)
+ *  unit.
+ *
+ *  @param[out]  aOutLevel  A mutable reference to storage for the
+ *                          resulting output volume level, if
+ *                          successful.
+ *
+ *  @retval  kStatus_Success        If successful.
+ *  @retval  kError_NotInitialized  If the output volume level value
+ *                                  has not been initialized with a
+ *                                  known value.
+ *  @retval  -ERANGE                The attempted adjustment would result
+ *                                  in a level that would exceed the
+ *                                  maximum output volume level.
+ *
+ *  @sa SetVolume
+ *
+ *  @ingroup volume
+ *
+ */
+Status
+OutputModelBasis :: IncreaseVolume(LevelType &aOutLevel)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mVolume.IncreaseVolume(aOutLevel);
+    nlREQUIRE(lRetval >= kStatus_Success, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This sets the model output identifier.
+ *
+ *  This attempts to set the model with the output identifier.
+ *
+ *  @param[in]  aIdentifier  An immutable reference to the output
+ *                           identifier to set.
+ *
+ *  @retval  kStatus_Success          If successful.
+ *  @retval  kStatus_ValueAlreadySet  The specified @a aIdentifier value
+ *                                    has already been set.
+ *  @retval  -EINVAL                  The specified @a aIdentifier value
+ *                                    is invalid.
+ *
+ */
+Status
+OutputModelBasis :: SetIdentifier(const IdentifierType &aIdentifier)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mIdentifier.SetIdentifier(aIdentifier);
+    nlREQUIRE(lRetval >= kStatus_Success, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This sets the model output name.
+ *
+ *  This attempts to set the model with the specified output name.
+ *
+ *  @param[in]  aName        A pointer to the start of the null-
+ *                           terminated C string name to set.
+ *
+ *  @retval  kStatus_Success          If successful.
+ *  @retval  kStatus_ValueAlreadySet  The specified name has already
+ *                                    been set.
+ *  @retval  -EINVAL                  If @a aName was null.
+ *  @retval  -ENAMETOOLONG            If @a aName was too long.
+ *
+ *  @ingroup name
+ *
+ */
+Status
+OutputModelBasis :: SetName(const char *aName)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mName.SetName(aName);
+    nlREQUIRE(lRetval >= kStatus_Success, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This sets the model output name.
+ *
+ *  This attempts to set the model with the specified output name
+ *  extent.
+ *
+ *  @param[in]  aName        A pointer to the start of the string name
+ *                           to set.
+ *  @param[in]  aNameLength  An immutable reference to the length,
+ *                           in bytes, of @a aName.
+ *
+ *  @retval  kStatus_Success          If successful.
+ *  @retval  kStatus_ValueAlreadySet  The specified name has already
+ *                                    been set.
+ *  @retval  -EINVAL                  If @a aName was null.
+ *  @retval  -ENAMETOOLONG            If @a aNameLength was too long.
+ *
+ *  @ingroup name
+ *
+ */
+Status
+OutputModelBasis :: SetName(const char *aName, const size_t &aNameLength)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mName.SetName(aName, aNameLength);
+    nlREQUIRE(lRetval >= kStatus_Success, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This sets the model output volume mute state.
+ *
+ *  This attempts to set the model with the specified output volume
+ *  mute state.
+ *
+ *  @param[in]  aMute  An immutable reference to the output
+ *                     volume mute state to set.
+ *
+ *  @retval  kStatus_Success          If successful.
+ *  @retval  kStatus_ValueAlreadySet  The specified @a aMute value
+ *                                    has already been set.
+ *
+ *  @ingroup volume
+ *
+ */
+Status
+OutputModelBasis :: SetMute(const MuteType &aMute)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mVolume.SetMute(aMute);
+    nlREQUIRE(lRetval >= kStatus_Success, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This sets the model output volume level.
+ *
+ *  This attempts to set the model with the specified output volume
+ *  level.
+ *
+ *  @param[in]  aLevel  An immutable reference to the output volume
+ *                      level to set.
+ *
+ *  @retval  kStatus_Success          If successful.
+ *  @retval  kStatus_ValueAlreadySet  The specified @a aLevel value
+ *                                    has already been set.
+ *  @retval  -ERANGE                  The specified @a aLevel value
+ *                                    is out of range.
+ *
+ *  @ingroup volume
+ *
+ */
+Status
+OutputModelBasis :: SetVolume(const LevelType &aLevel)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mVolume.SetVolume(aLevel);
+    nlREQUIRE(lRetval >= kStatus_Success, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    Attempt to toggle (flip) the model output volume mute state.
+ *
+ *  This attempts to toggle (flip) the model output volume mute state.
+ *
+ *  @param[out]  aOutMute  A mutable reference to storage for the
+ *                         resulting output volume mute state, if
+ *                         successful.
+ *
+ *  @retval  kStatus_Success        If successful.
+ *  @retval  kError_NotInitialized  If the output volume mute state
+ *                                  value has not been initialized
+ *                                  with a known value.
+ *
+ *  @ingroup volume
+ *
+ */
+Status
+OutputModelBasis :: ToggleMute(MuteType &aOutMute)
+{
+    Status lRetval = kStatus_Success;
+
+    lRetval = mVolume.ToggleMute(aOutMute);
+    nlREQUIRE(lRetval >= kStatus_Success, done);
+
+ done:
+    return (lRetval);
+}
+
+/**
+ *  @brief
+ *    This is a class equality operator.
+ *
+ *  This compares the provided output model against this one to
+ *  determine if they are equal to one another.
+ *
+ *  @param[in]  aOutputModelBasis  An immutable reference to the output
+ *                           model to compare for equality.
+ *
+ *  @returns
+ *    True if this output model is equal to the specified one;
+ *    otherwise, false.
+ *
+ */
+bool
+OutputModelBasis :: operator ==(const OutputModelBasis &aOutputModelBasis) const
+{
+    return ((mIdentifier == aOutputModelBasis.mIdentifier) &&
+            (mName       == aOutputModelBasis.mName      ) &&
+            (mVolume     == aOutputModelBasis.mVolume    ));
+}
+
+}; // namespace Model
+
+}; // namespace HLX

--- a/src/lib/model/OutputModelBasis.hpp
+++ b/src/lib/model/OutputModelBasis.hpp
@@ -1,0 +1,140 @@
+/*
+ *    Copyright (c) 2024 Grant Erickson
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing,
+ *    software distributed under the License is distributed on an "AS
+ *    IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied.  See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ */
+
+/**
+ *    @file
+ *      This file defines an object for managing a HLX output data model.
+ *
+ */
+
+#ifndef OPENHLXMMODELOUTPUTMODELBASIS_HPP
+#define OPENHLXMMODELOUTPUTMODELBASIS_HPP
+
+#include <string>
+
+#include <stddef.h>
+
+#include <OpenHLX/Common/Errors.hpp>
+#include <OpenHLX/Model/IdentifierModel.hpp>
+#include <OpenHLX/Model/NameModel.hpp>
+#include <OpenHLX/Model/VolumeModel.hpp>
+
+
+namespace HLX
+{
+
+namespace Model
+{
+
+/**
+ *  @brief
+ *    An object for managing a HLX output data model.
+ *
+ *  @ingroup model
+ *  @ingroup output
+ *
+ */
+class OutputModelBasis
+{
+public:
+    static const size_t kNameLengthMax;
+
+    /**
+     *  Convenience type redeclaring @a IdentifierType from the
+     *  identifier model.
+     *
+     */
+    typedef IdentifierModel::IdentifierType IdentifierType;
+    /**
+     *  Convenience type redeclaring @a MuteType from the
+     *  volume model.
+     *
+     */
+    typedef VolumeModel::MuteType           MuteType;
+
+    /**
+     *  Convenience type redeclaring @a LevelType from the
+     *  volume model.
+     *
+     */
+    typedef VolumeModel::LevelType          LevelType;
+
+public:
+    // Destruction
+
+    virtual ~OutputModelBasis(void) = default;
+
+protected:
+    // Construction
+
+    OutputModelBasis(void) = default;
+
+    // Initialization
+
+    Common::Status Init(void);
+    Common::Status Init(const char *aName, const IdentifierType &aIdentifier);
+    Common::Status Init(const char *aName, const size_t &aNameLength, const IdentifierType &aIdentifier);
+    Common::Status Init(const std::string &aName, const IdentifierType &aIdentifier);
+    Common::Status Init(const OutputModelBasis &aOutputModelBasis);
+
+    OutputModelBasis &operator =(const OutputModelBasis &aOutputModelBasis);
+
+public:
+    // Observation
+
+    Common::Status GetIdentifier(IdentifierType &aIdentifier) const;
+    Common::Status GetName(const char *&aName) const;
+    Common::Status GetMute(MuteType &aMute) const;
+    Common::Status GetVolume(LevelType &aVolume) const;
+
+    // Mutation
+
+    Common::Status DecreaseVolume(LevelType &aOutLevel);
+    Common::Status IncreaseVolume(LevelType &aOutLevel);
+    Common::Status SetIdentifier(const IdentifierType &aIdentifier);
+    Common::Status SetName(const char *aName);
+    Common::Status SetName(const char *aName, const size_t &aNameLength);
+    Common::Status SetMute(const MuteType &aMute);
+    Common::Status SetVolume(const LevelType &aVolume);
+    Common::Status ToggleMute(MuteType &aOutMute);
+
+    // Equality
+
+    bool operator ==(const OutputModelBasis &aOutputModelBasis) const;
+
+private:
+    // We can: 1) make all three data members protected just so that
+    // the zone model can access the volume model for the fixed volume
+    // methods, 2) make none protected but make the zone model a
+    // friend, or 3) move fixed volume out of the volume model and
+    // into the zone model. Pursuing (2) seems the most reasonable
+    // trade-off between breaking encapsulation and keeping like
+    // properties and methods together.
+
+    friend class ZoneModel;
+
+    IdentifierModel  mIdentifier;
+    NameModel        mName;
+    VolumeModel      mVolume;
+};
+
+}; // namespace Model
+
+}; // namespace HLX
+
+#endif // OPENHLXMMODELOUTPUTMODELBASIS_HPP

--- a/src/lib/model/ZoneModel.cpp
+++ b/src/lib/model/ZoneModel.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2018-2021 Grant Erickson
+ *    Copyright (c) 2018-2024 Grant Erickson
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,12 +43,6 @@ namespace Model
 {
 
 /**
- *  The maximum allowed length, in bytes, of a zone name.
- *
- */
-const size_t ZoneModel::kNameLengthMax = NameModel::kNameLengthMax;
-
-/**
  *  @brief
  *    This is the class default initializer.
  *
@@ -65,22 +59,16 @@ ZoneModel :: Init(void)
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
+    lRetval = OutputModelBasis::Init();
+    nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mBalance.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mName.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSoundModel.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSourceIdentifier.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mVolume.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
  done:
@@ -114,22 +102,16 @@ ZoneModel :: Init(const char *aName, const IdentifierType &aIdentifier)
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init(aIdentifier);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
+    lRetval = OutputModelBasis::Init(aName, aIdentifier);
+    nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mBalance.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mName.Init(aName);
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSoundModel.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSourceIdentifier.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mVolume.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
  done:
@@ -166,22 +148,16 @@ ZoneModel :: Init(const char *aName, const size_t &aNameLength, const Identifier
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init(aIdentifier);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
+    lRetval = OutputModelBasis::Init(aName, aNameLength, aIdentifier);
+    nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mBalance.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mName.Init(aName, aNameLength);
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSoundModel.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSourceIdentifier.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mVolume.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
  done:
@@ -215,22 +191,16 @@ ZoneModel :: Init(const std::string &aName, const IdentifierType &aIdentifier)
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init(aIdentifier);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
+    lRetval = OutputModelBasis::Init(aName, aIdentifier);
+    nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mBalance.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mName.Init(aName);
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSoundModel.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSourceIdentifier.Init();
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mVolume.Init();
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
  done:
@@ -260,22 +230,16 @@ ZoneModel :: Init(const ZoneModel &aZoneModel)
 {
     Status lRetval = kStatus_Success;
 
-    lRetval = mIdentifier.Init(aZoneModel.mIdentifier);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
+    lRetval = OutputModelBasis::Init(aZoneModel);
+    nlREQUIRE_SUCCESS(lRetval, done);
 
     lRetval = mBalance.Init(aZoneModel.mBalance);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mName.Init(aZoneModel.mName);
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSoundModel.Init(aZoneModel.mSoundModel);
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
     lRetval = mSourceIdentifier.Init(aZoneModel.mSourceIdentifier);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
-    lRetval = mVolume.Init(aZoneModel.mVolume);
     nlREQUIRE(lRetval >= kStatus_Success, done);
 
  done:
@@ -306,79 +270,13 @@ ZoneModel :: Init(const ZoneModel &aZoneModel)
 ZoneModel &
 ZoneModel :: operator =(const ZoneModel &aZoneModel)
 {
-    mIdentifier       = aZoneModel.mIdentifier;
+    OutputModelBasis::operator =(aZoneModel);
+
     mBalance          = aZoneModel.mBalance;
-    mName             = aZoneModel.mName;
     mSoundModel       = aZoneModel.mSoundModel;
     mSourceIdentifier = aZoneModel.mSourceIdentifier;
-    mVolume           = aZoneModel.mVolume;
 
     return (*this);
-}
-
-/**
- *  @brief
- *    Attempt to get the zone identifier.
- *
- *  This attempts to get the zone identifier, if it has been
- *  previously initialized or set.
- *
- *  @param[out]  aIdentifier  A mutable reference to storage for the
- *                            zone identifier, if successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the zone identifier
- *                                  value has not been initialized
- *                                  with a known value.
- *
- *  @sa Init
- *  @sa SetIdentifier
- *
- */
-Status
-ZoneModel :: GetIdentifier(IdentifierType &aIdentifier) const
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mIdentifier.GetIdentifier(aIdentifier);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    Attempt to get the zone name
- *
- *  This attempts to get the zone name, if it has been previously
- *  initialized or set.
- *
- *  @param[out]  aName  A reference to pointer to an immutable
- *                      null-terminated C string for the zone
- *                      name, if successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the zone name value has
- *                                  not been initialized with a known
- *                                  value.
- *
- *  @sa Init
- *  @sa SetIdentifier
- *
- *  @ingroup name
- *
- */
-Status
-ZoneModel :: GetName(const char *&aName) const
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mName.GetName(aName);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
- done:
-    return (lRetval);
 }
 
 /**
@@ -726,37 +624,6 @@ ZoneModel :: GetLowpassFrequency(CrossoverModel::FrequencyType &aLowpassFrequenc
 
 /**
  *  @brief
- *    Attempt to get the model zone volume mute state.
- *
- *  This attempts to get the model zone volume mute state, if it has
- *  been previously initialized or set.
- *
- *  @param[out]  aMute  A mutable reference to storage for the
- *                      zone volume mute state, if successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the zone volume mute state
- *                                  value has not been initialized
- *                                  with a known value.
- *
- *  @sa SetMute
- *  @sa ToggleMute
- *
- */
-Status
-ZoneModel :: GetMute(MuteType &aMute) const
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.GetMute(aMute);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
  *    Attempt to get the model equalizer sound mode.
  *
  *  This attempts to get the model equalizer sound mode, if it has
@@ -867,38 +734,6 @@ ZoneModel :: GetTreble(ToneModel::LevelType &aTreble) const
     Status lRetval = kStatus_Success;
 
     lRetval = mSoundModel.GetTreble(aTreble);
-    nlREQUIRE_SUCCESS(lRetval, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    Attempt to get the model zone volume level.
- *
- *  This attempts to get the model zone volume level, if it has been
- *  previously initialized or set.
- *
- *  @param[out]  aLevel  A mutable reference to storage for the
- *                       zone volume level, if successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the zone volume level value
- *                                  has not been initialized with a
- *                                  known value.
- *
- *  @sa SetVolume
- *
- *  @ingroup volume
- *
- */
-Status
-ZoneModel :: GetVolume(LevelType &aLevel) const
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.GetVolume(aLevel);
     nlREQUIRE_SUCCESS(lRetval, done);
 
  done:
@@ -1130,170 +965,6 @@ ZoneModel :: IncreaseTreble(ToneModel::LevelType &aOutTreble)
 
 /**
  *  @brief
- *    Decrease the model zone volume level by one (1) unit.
- *
- *  This attempts to decrease the model zone volume level by one (1)
- *  unit.
- *
- *  @param[out]  aOutLevel  A mutable reference to storage for the
- *                          resulting zone volume level, if
- *                          successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the zone volume level value
- *                                  has not been initialized with a
- *                                  known value.
- *  @retval  -ERANGE                The attempted adjustment would result
- *                                  in a level that would exceed the
- *                                  minimum zone volume level.
- *
- *  @sa SetVolume
- *
- *  @ingroup volume
- *
- */
-Status
-ZoneModel :: DecreaseVolume(LevelType &aOutLevel)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.DecreaseVolume(aOutLevel);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    Increase the model zone volume level by one (1) unit.
- *
- *  This attempts to increase the model zone volume level by one (1)
- *  unit.
- *
- *  @param[out]  aOutLevel  A mutable reference to storage for the
- *                          resulting zone volume level, if
- *                          successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the zone volume level value
- *                                  has not been initialized with a
- *                                  known value.
- *  @retval  -ERANGE                The attempted adjustment would result
- *                                  in a level that would exceed the
- *                                  maximum zone volume level.
- *
- *  @sa SetVolume
- *
- *  @ingroup volume
- *
- */
-Status
-ZoneModel :: IncreaseVolume(LevelType &aOutLevel)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.IncreaseVolume(aOutLevel);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    This sets the model zone identifier.
- *
- *  This attempts to set the model with the zone
- *  identifier.
- *
- *  @param[in]  aIdentifier  An immutable reference to the zone
- *                           identifier to set.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified @a aIdentifier value
- *                                    has already been set.
- *  @retval  -EINVAL                  The specified @a aIdentifier value
- *                                    is invalid.
- *
- */
-Status
-ZoneModel :: SetIdentifier(const IdentifierType &aIdentifier)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mIdentifier.SetIdentifier(aIdentifier);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    This sets the model zone name.
- *
- *  This attempts to set the model with the specified zone name.
- *
- *  @param[in]  aName        A pointer to the start of the null-
- *                           terminated C string name to set.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified name has already
- *                                    been set.
- *  @retval  -EINVAL                  If @a aName was null.
- *  @retval  -ENAMETOOLONG            If @a aName was too long.
- *
- *  @ingroup name
- *
- */
-Status
-ZoneModel :: SetName(const char *aName)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mName.SetName(aName);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
- *    This sets the model zone name.
- *
- *  This attempts to set the model with the specified zone name
- *  extent.
- *
- *  @param[in]  aName        A pointer to the start of the string name
- *                           to set.
- *  @param[in]  aNameLength  An immutable reference to the length,
- *                           in bytes, of @a aName.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified name has already
- *                                    been set.
- *  @retval  -EINVAL                  If @a aName was null.
- *  @retval  -ENAMETOOLONG            If @a aNameLength was too long.
- *
- *  @ingroup name
- *
- */
-Status
-ZoneModel :: SetName(const char *aName, const size_t &aNameLength)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mName.SetName(aName, aNameLength);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
  *    This sets the model stereophonic channel balance.
  *
  *  This initializes the model with the specified stereophonic channel
@@ -1446,35 +1117,6 @@ ZoneModel :: SetLowpassFrequency(const CrossoverModel::FrequencyType &aLowpassFr
 
 /**
  *  @brief
- *    This sets the model zone volume mute state.
- *
- *  This attempts to set the model with the specified zone volume
- *  mute state.
- *
- *  @param[in]  aMute  An immutable reference to the zone
- *                     volume mute state to set.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified @a aMute value
- *                                    has already been set.
- *
- *  @ingroup volume
- *
- */
-Status
-ZoneModel :: SetMute(const MuteType &aMute)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.SetMute(aMute);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
  *    Attempt to set the model equalizer sound mode.
  *
  *  This attempts to set the model with the specified equalizer sound
@@ -1594,37 +1236,6 @@ ZoneModel :: SetTreble(const ToneModel::LevelType &aTreble)
 
 /**
  *  @brief
- *    This sets the model zone volume level.
- *
- *  This attempts to set the model with the specified zone volume
- *  level.
- *
- *  @param[in]  aLevel  An immutable reference to the zone volume
- *                      level to set.
- *
- *  @retval  kStatus_Success          If successful.
- *  @retval  kStatus_ValueAlreadySet  The specified @a aLevel value
- *                                    has already been set.
- *  @retval  -ERANGE                  The specified @a aLevel value
- *                                    is out of range.
- *
- *  @ingroup volume
- *
- */
-Status
-ZoneModel :: SetVolume(const LevelType &aLevel)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.SetVolume(aLevel);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
  *    This sets the model volume fixed/locked state.
  *
  *  This attempts to set the model with the specified volume
@@ -1654,36 +1265,6 @@ ZoneModel :: SetVolumeFixed(const VolumeFixedType &aVolumeFixed)
 
 /**
  *  @brief
- *    Attempt to toggle (flip) the model zone volume mute state.
- *
- *  This attempts to toggle (flip) the model zone volume mute state.
- *
- *  @param[out]  aOutMute  A mutable reference to storage for the
- *                         resulting zone volume mute state, if
- *                         successful.
- *
- *  @retval  kStatus_Success        If successful.
- *  @retval  kError_NotInitialized  If the zone volume mute state
- *                                  value has not been initialized
- *                                  with a known value.
- *
- *  @ingroup volume
- *
- */
-Status
-ZoneModel :: ToggleMute(MuteType &aOutMute)
-{
-    Status lRetval = kStatus_Success;
-
-    lRetval = mVolume.ToggleMute(aOutMute);
-    nlREQUIRE(lRetval >= kStatus_Success, done);
-
- done:
-    return (lRetval);
-}
-
-/**
- *  @brief
  *    This is a class equality operator.
  *
  *  This compares the provided zone model against this one to
@@ -1699,12 +1280,10 @@ ZoneModel :: ToggleMute(MuteType &aOutMute)
  */
 bool ZoneModel :: operator ==(const ZoneModel &aZoneModel) const
 {
-    return ((mIdentifier       == aZoneModel.mIdentifier      ) &&
-            (mName             == aZoneModel.mName            ) &&
-            (mBalance          == aZoneModel.mBalance         ) &&
-            (mSoundModel       == aZoneModel.mSoundModel      ) &&
-            (mSourceIdentifier == aZoneModel.mSourceIdentifier) &&
-            (mVolume           == aZoneModel.mVolume          ));
+    return (OutputModelBasis::operator ==(aZoneModel)                   &&
+            (mBalance                  == aZoneModel.mBalance         ) &&
+            (mSoundModel               == aZoneModel.mSoundModel      ) &&
+            (mSourceIdentifier         == aZoneModel.mSourceIdentifier));
 }
 
 }; // namespace Model

--- a/src/lib/model/ZoneModel.hpp
+++ b/src/lib/model/ZoneModel.hpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2018-2021 Grant Erickson
+ *    Copyright (c) 2018-2024 Grant Erickson
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,11 +33,9 @@
 #include <OpenHLX/Common/Errors.hpp>
 #include <OpenHLX/Model/BalanceModel.hpp>
 #include <OpenHLX/Model/EqualizerPresetModel.hpp>
-#include <OpenHLX/Model/IdentifierModel.hpp>
-#include <OpenHLX/Model/NameModel.hpp>
+#include <OpenHLX/Model/OutputModelBasis.hpp>
 #include <OpenHLX/Model/SoundModel.hpp>
 #include <OpenHLX/Model/SourceModel.hpp>
-#include <OpenHLX/Model/VolumeModel.hpp>
 
 
 namespace HLX
@@ -54,18 +52,10 @@ namespace Model
  *  @ingroup zone
  *
  */
-class ZoneModel
+class ZoneModel :
+    public OutputModelBasis
 {
 public:
-    static const size_t kNameLengthMax;
-
-    /**
-     *  Convenience type redeclaring @a IdentifierType from the
-     *  identifier model.
-     *
-     */
-    typedef IdentifierModel::IdentifierType IdentifierType;
-
     /**
      *  Convenience type redeclaring @a BalanceType from the
      *  balance model.
@@ -94,20 +84,6 @@ public:
      */
     typedef VolumeModel::FixedType          VolumeFixedType;
 
-    /**
-     *  Convenience type redeclaring @a MuteType from the
-     *  volume model.
-     *
-     */
-    typedef VolumeModel::MuteType           MuteType;
-
-    /**
-     *  Convenience type redeclaring @a LevelType from the
-     *  volume model.
-     *
-     */
-    typedef VolumeModel::LevelType          LevelType;
-
 public:
     ZoneModel(void) = default;
     virtual ~ZoneModel(void) = default;
@@ -120,8 +96,6 @@ public:
 
     ZoneModel &operator =(const ZoneModel &aZoneModel);
 
-    Common::Status GetIdentifier(IdentifierType &aIdentifier) const;
-    Common::Status GetName(const char *&aName) const;
     Common::Status GetBalance(BalanceType &aBalance) const;
     Common::Status GetBass(ToneModel::LevelType &aBass) const;
     Common::Status GetChannelMode(ChannelMode &aChannelMode) const;
@@ -134,48 +108,35 @@ public:
     Common::Status GetLowpassCrossover(CrossoverModel *&aLowpassCrossoverModel);
     Common::Status GetLowpassCrossover(const CrossoverModel *&aLowpassCrossoverModel) const;
     Common::Status GetLowpassFrequency(CrossoverModel::FrequencyType &aLowpassFrequency) const;
-    Common::Status GetMute(MuteType &aMute) const;
     Common::Status GetSoundMode(SoundMode &aSoundMode) const;
     Common::Status GetSource(SourceModel::IdentifierType &aSourceIdentifier) const;
     Common::Status GetTone(ToneModel::LevelType &aBass, ToneModel::LevelType &aTreble) const;
     Common::Status GetTreble(ToneModel::LevelType &aTreble) const;
-    Common::Status GetVolume(LevelType &aVolume) const;
     Common::Status GetVolumeFixed(VolumeFixedType &aVolumeFixed) const;
 
     Common::Status DecreaseBass(ToneModel::LevelType &aOutBass);
     Common::Status DecreaseTreble(ToneModel::LevelType &aOutTreble);
-    Common::Status DecreaseVolume(LevelType &aOutLevel);
     Common::Status IncreaseBalanceLeft(BalanceType &aOutBalance);
     Common::Status IncreaseBalanceRight(BalanceType &aOutBalance);
     Common::Status IncreaseBass(ToneModel::LevelType &aOutBass);
     Common::Status IncreaseTreble(ToneModel::LevelType &aOutTreble);
-    Common::Status IncreaseVolume(LevelType &aOutLevel);
     Common::Status SetBalance(const BalanceType &aBalance);
     Common::Status SetBass(const ToneModel::LevelType &aBass);
     Common::Status SetEqualizerPreset(const EqualizerPresetModel::IdentifierType &aEqualizerPresetIdentifier);
     Common::Status SetHighpassFrequency(const CrossoverModel::FrequencyType &aHighpassFrequency);
-    Common::Status SetIdentifier(const IdentifierType &aIdentifier);
     Common::Status SetLowpassFrequency(const CrossoverModel::FrequencyType &aLowpassFrequency);
-    Common::Status SetMute(const MuteType &aMute);
-    Common::Status SetName(const char *aName);
-    Common::Status SetName(const char *aName, const size_t &aNameLength);
     Common::Status SetSoundMode(const SoundMode &aSoundMode);
     Common::Status SetSource(const SourceModel::IdentifierType &aSourceIdentifier);
     Common::Status SetTone(const ToneModel::LevelType &aBass, const ToneModel::LevelType &aTreble);
     Common::Status SetTreble(const ToneModel::LevelType &aTreble);
-    Common::Status SetVolume(const LevelType &aVolume);
     Common::Status SetVolumeFixed(const VolumeFixedType &aVolumeFixed);
-    Common::Status ToggleMute(MuteType &aOutMute);
 
     bool operator ==(const ZoneModel &aZoneModel) const;
 
 private:
-    IdentifierModel mIdentifier;
     BalanceModel    mBalance;
-    NameModel       mName;
     SoundModel      mSoundModel;
     IdentifierModel mSourceIdentifier;
-    VolumeModel     mVolume;
 };
 
 }; // namespace Model


### PR DESCRIPTION
This addresses #23 by rebasing the `GroupModel` and `ZoneModel` output model classes on a common ancestor, `OutputModelBasis` which is composed of a identifier, name, and volume model instance.